### PR TITLE
fix problem day 35 - median

### DIFF
--- a/day 35 - median.ipynb
+++ b/day 35 - median.ipynb
@@ -35,10 +35,10 @@
     "    split = np.sum(items <= pivot)\n",
     "    \n",
     "    # search partition\n",
-    "    if k < split:\n",
-    "        return kth(items[items <= pivot], k, depth + 1)\n",
+    "    if k <= split:\n",
+    "        return kth([i for i in items if i <= pivot], k, depth + 1)\n",
     "    else:\n",
-    "        return kth(items[items > pivot], k - split, depth + 1)"
+    "        return kth([i for i in items if i > pivot], k - split, depth + 1)"
    ]
   },
   {


### PR DESCRIPTION
- replaced pseudocode `items[items <= pivot]` with list comprehension `[i for i in items if i <= pivot]`
- handled case where `k == split`